### PR TITLE
Spring Binstubs, Shoulda-Matchers and Destination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :test do
   gem 'capybara', '~> 2.8'
   gem 'capybara-webkit'
   gem 'database_cleaner', '~> 1.3'
-  gem 'shoulda-matchers', '~> 2.8'
+  gem 'shoulda-matchers', '~> 2.8', require: false
   gem 'codeclimate-test-reporter', require: nil
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'spring'
   gem 'launchy'
+  gem 'spring-commands-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,8 @@ GEM
       ffi
     spring (2.0.1)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -538,6 +540,7 @@ DEPENDENCIES
   sidekiq
   slim-rails
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   stackprof
   switch_user

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: destinations
+#
+#  id         :integer          not null, primary key
+#  match_id   :integer
+#  map_id     :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Destination, type: :model do
+  context 'associations' do
+    it { is_expected.to belong_to :match }
+    it { is_expected.to belong_to :map }
+  end
+end


### PR DESCRIPTION
I've generated Spring binstubs for the app including for spec. This is to speed up running the specs. That required adding require: false for the shoulda-matchers gem. Also I wrote specs for the Destination model to verify that spring and shoulda-matchers actually was working.